### PR TITLE
Use ansible_distribution_release to fix debian compatibility

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -5,10 +5,8 @@ monsieurbiz_mariadb_tags: [monsieurbiz, mariadb, database, sql, db]
 
 monsieurbiz_mariadb_apt_key: "http://keyserver.ubuntu.com/pks/lookup?op=get&fingerprint=on&search=0xcbcb082a1bb943db"
 
-# Jessie
-monsieurbiz_mariadb_repository: "deb [arch=amd64,i386] http://ftp.igh.cnrs.fr/pub/mariadb/repo/10.1/debian jessie main"
-# Wheezy
-# monsieurbiz_mariadb_repository: "deb [arch=amd64,i386] http://ftp.igh.cnrs.fr/pub/mariadb/repo/10.1/debian wheezy main"
+# ansible_distribution_release
+monsieurbiz_mariadb_repository: "deb [arch=amd64,i386] http://ftp.igh.cnrs.fr/pub/mariadb/repo/10.1/debian {{ ansible_distribution_release }} main"
 
 monsieurbiz_mariadb_use_root_conf: yes
 


### PR DESCRIPTION
- Use {{ ansible_distribution_release }} to fix debian compatibility